### PR TITLE
CI checks for Lua lint/format via Nix dev shell

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Normalize line endings for text files on checkout
+* text=auto
+
+# Shell scripts must stay LF so scripts/lint.sh and format.sh run anywhere
+*.sh text eol=lf
+
+# Lua source keeps LF to match luacheck/stylua output and avoid EOL churn
+*.lua text eol=lf
+
+# Nix and YAML are human-edited config; keep LF for consistent diffing
+*.nix text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Markdown and TOML: gentle normalization, no hard forcing
+*.md text eol=lf
+*.toml text eol=lf
+
+# Capture files are binary and must never be re-encoded or diffed as text
+*.pcap binary
+*.pcapng binary

--- a/.github/workflows/lua-checks.yml
+++ b/.github/workflows/lua-checks.yml
@@ -1,0 +1,36 @@
+name: lua-checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          flake: true
+      - name: Run lint
+        run: nix develop --command ./scripts/lint.sh
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          flake: true
+      - name: Run format check
+        run: nix develop --command ./scripts/format.sh --check

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ luac.out
 *.x86_64
 *.hex
 
+# Speckit workflow tooling (not part of the shipped project)
+.specify/
+specs/
+.opencode/
+

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,22 @@
+stds.wireshark = {
+    globals = {
+        "Proto",
+        "ProtoField",
+        "Pref",
+        "DissectorTable",
+        "bit",
+        "base",
+        "ByteArray",
+        "Tvb",
+        "TvbRange",
+        "TreeItem",
+        "Pinfo",
+        "DESEGMENT_ONE_MORE_SEGMENT",
+        "ZabProto",
+    },
+    read_globals = {
+    }
+}
+std = "lua52+wireshark"
+max_line_length = 140
+unused_args = false

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"

--- a/README.md
+++ b/README.md
@@ -92,3 +92,21 @@ $ luarocks install luacheck   # Lua linter
 $ brew install stylua         # or: cargo install stylua
 ```
 
+The recommended way to get the exact tool versions used by CI is the Nix dev
+shell defined by `flake.nix`:
+
+``` shell
+$ nix develop                                            # enter the dev shell
+$ nix develop --command ./scripts/lint.sh                # lint (no shell entry)
+$ nix develop --command ./scripts/format.sh --check      # format check (no shell entry)
+```
+
+`nix develop` provides `luacheck` and `stylua` pinned by `flake.lock`, so local
+runs and CI use identical tooling.
+
+Every pull request is validated automatically by the CI workflow
+`.github/workflows/lua-checks.yml`, which runs exactly these two commands
+(`./scripts/lint.sh` and `./scripts/format.sh --check`) inside the Nix dev
+shell. A PR only turns green when both checks pass, so the same commands used
+locally are what CI enforces.
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ $ tshark  \
     -VOzab  -Yzab -x | view -
 ```
 
+A client may talk to many servers on different ports. Use the `ports=` argument
+to register several ports at once (this is useful for cluster scenarios):
+
+``` shell
+$ tshark \
+    -X lua_script:zab.lua \
+    -X lua_script1:ports=2181,2182,20000 \
+    -r <capture file> -Yzab
+```
+
+`port=N` always sets a single port (and is equivalent to `ports=N`), so the
+single-port form remains fully backward compatible.
+
 For the Wireshark GUI
 
 Windows:
@@ -58,5 +71,24 @@ I also recommend setting some high buffer to avoid any packet drops by BPF.
     -s 0 -B 919400 \
     -w <path to capture file> \
     tcp port 2181
+```
+
+Code quality tooling
+--------------------
+
+The project ships two portable shell runners for Lua code quality. Both exit
+with status `0` on clean code and `1` when issues are found.
+
+``` shell
+$ ./scripts/lint.sh        # run luacheck against zab.lua
+$ ./scripts/format.sh      # format zab.lua in place (stylua)
+$ ./scripts/format.sh --check  # verify zab.lua is formatted (no changes)
+```
+
+Install the underlying tools if they are missing:
+
+``` shell
+$ luarocks install luacheck   # Lua linter
+$ brew install stylua         # or: cargo install stylua
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787101114,
+        "narHash": "sha256-gwrPcFf/rDjHPaVflbDZ040ZDmBTRj/7+s8ZmE2SaIM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b18a4b905f8d028dc4476412e6d6891728695379",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Development environment for the ZAB Wireshark dissector";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              stylua
+              luaPackages.luacheck
+            ];
+          };
+        }
+      );
+    };
+}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -e
+
+if ! command -v stylua >/dev/null 2>&1; then
+    echo "error: stylua is not installed." >&2
+    echo "Install it with one of:" >&2
+    echo "  brew install stylua" >&2
+    echo "  cargo install stylua" >&2
+    exit 1
+fi
+
+if [ "$1" = "--check" ]; then
+    stylua --check --config-path .stylua.toml zab.lua
+else
+    stylua --config-path .stylua.toml zab.lua
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -e
+
+if ! command -v luacheck >/dev/null 2>&1; then
+    echo "error: luacheck is not installed." >&2
+    echo "Install it with one of:" >&2
+    echo "  luarocks install luacheck" >&2
+    echo "  brew install luacheck" >&2
+    exit 1
+fi
+
+luacheck zab.lua --config .luacheckrc

--- a/zab.lua
+++ b/zab.lua
@@ -24,7 +24,7 @@
 -- Logging config and functions, and replace all prints
 
 local DEFAULT_ZAB_PORT = 2181
-local MAX_REQUEST_SIZE = 100 * 1024 * 1024
+local MAX_REQUEST_SIZE = 100 * 1024 * 1024 -- luacheck: ignore MAX_REQUEST_SIZE
 
 local FOUR_LETTER_WORDS = {
     ["conf"] = true,
@@ -39,7 +39,7 @@ local FOUR_LETTER_WORDS = {
     ["wchs"] = true,
     ["wchc"] = true,
     ["wchp"] = true,
-    ["mntr"] = true
+    ["mntr"] = true,
 }
 
 local FIXED_XIDS = {
@@ -47,7 +47,7 @@ local FIXED_XIDS = {
     [-1] = "WATCH_XID",
     [-2] = "PING_XID",
     [-4] = "AUTH_XID",
-    [-8] = "SET_WATCHES_XID"
+    [-8] = "SET_WATCHES_XID",
 }
 
 local opCodes = {
@@ -72,7 +72,7 @@ local opCodes = {
     [-10] = "CREATESESSION",
     [-11] = "CLOSE",
     [100] = "SETAUTH",
-    [101] = "SETWATCHES"
+    [101] = "SETWATCHES",
 }
 
 local watchEventTypes = {
@@ -80,7 +80,7 @@ local watchEventTypes = {
     [1] = "NodeCreated",
     [2] = "NodeDeleted",
     [3] = "NodeDataChanged",
-    [4] = "NodeChildrenChanged"
+    [4] = "NodeChildrenChanged",
 }
 
 local errorCodes = {
@@ -110,61 +110,60 @@ local errorCodes = {
     [-119] = "ConnectionClosedError",
 }
 
-local f_pkt             = ProtoField.none("zab.pkt", "Packet")
-local f_op              = ProtoField.none("zab.op", "Operation")
+local f_pkt = ProtoField.none("zab.pkt", "Packet")
+local f_op = ProtoField.none("zab.op", "Operation")
 
-local f_4lw             = ProtoField.string("zab.4lw", "4LW message")
-local f_protoversion    = ProtoField.uint64("zab.protocolversion", "Protocol Version")
-local f_zxid            = ProtoField.uint64("zab.zxid", "ZxID", base.HEX)
-local f_zxid_epoch      = ProtoField.uint32("zab.zxid.epoch", "Epoch")
-local f_zxid_count      = ProtoField.uint32("zab.zxid.count", "Count")
-local f_czxid           = ProtoField.uint64("zab.czxid", "Created ZxID", base.HEX)
-local f_czxid_epoch     = ProtoField.uint32("zab.czxid.epoch", "Epoch")
-local f_czxid_count     = ProtoField.uint32("zab.czxid.count", "Count")
-local f_mzxid           = ProtoField.uint64("zab.mzxid", "Last Modified ZxID", base.HEX)
-local f_mzxid_epoch     = ProtoField.uint32("zab.mzxid.epoch", "Epoch")
-local f_mzxid_count     = ProtoField.uint32("zab.mzxid.count", "Count")
-local f_pzxid           = ProtoField.uint64("zab.pzxid", "Last Modified Children ZxID", base.HEX)
-local f_pzxid_epoch     = ProtoField.uint32("zab.pzxid.epoch", "Epoch")
-local f_pzxid_count     = ProtoField.uint32("zab.pzxid.count", "Count")
-local f_timeout         = ProtoField.uint32("zab.timeout", "Timeout")
-local f_session         = ProtoField.uint64("zab.session", "Session ID", base.HEX)
-local f_len             = ProtoField.uint32("zab.length", "Length", base.INT)
-local f_passwd          = ProtoField.bytes("zab.passwd", "Password")
-local f_xid             = ProtoField.int32("zab.xid", "Transaction ID", base.INT)
-local f_opCode          = ProtoField.int32("zab.opcode", "OpCode", base.INT, opCodes)
-local f_data            = ProtoField.bytes("zab.data", "Data")
-local f_path            = ProtoField.string("zab.path", "Path")
-local f_watch           = ProtoField.bool("zab.watch", "Watch")
-local f_ctime           = ProtoField.uint64("zab.ctime", "Created", base.RELATIVE_TIME)
-local f_mtime           = ProtoField.uint64("zab.mtime", "Last Modified", base.RELATIVE_TIME)
-local f_ephemeralowner  = ProtoField.uint64("zab.ephemeralowner", "Ephemeral Owner", base.HEX)
-local f_numchildren     = ProtoField.uint64("zab.numchildren", "Number of Children")
-local f_datalength      = ProtoField.uint64("zab.datalength", "Data Length")
-local f_done            = ProtoField.bool("zab.done", "Done")
-local f_err             = ProtoField.int64("zab.err", "Error", base.INT, errorCodes)
-local f_perms           = ProtoField.int64("zab.permissions", "Permissions")
-local f_authtype        = ProtoField.int32("zab.authtype", "Authentication Type")
-local f_scheme          = ProtoField.string("zab.scheme", "Scheme")
-local f_credential      = ProtoField.string("zab.credential", "Credentials")
-local f_flags           = ProtoField.uint32("zab.flags", "Flags", base.HEX)
-local f_ephemeral       = ProtoField.bool("zab.ephemeral", "Ephemeral")
-local f_sequence        = ProtoField.bool("zab.sequence", "Sequence")
-local f_container       = ProtoField.bool("zab.container", "Container")
-local f_ttl             = ProtoField.uint64("zab.ttl", "TTL")
-local f_joining         = ProtoField.string("zab.joining", "Joining")
-local f_leaving         = ProtoField.string("zab.leaving", "Leaving")
-local f_newmembers      = ProtoField.string("zab.newmembers", "New Members")
-local f_config_id       = ProtoField.uint64("zab.config_id", "Config ID", base.HEX)
-local f_version         = ProtoField.uint64("zab.version", "Version")
-local f_cversion        = ProtoField.uint64("zab.cversion", "Child Version")
-local f_aversion        = ProtoField.uint64("zab.aversion", "ACL Version")
-local f_readonly        = ProtoField.bool("zab.readonly", "Readonly")
-local f_eventtype       = ProtoField.uint32("zab.eventtype", "Event Type", base.INT, watchEventTypes)
-local f_count           = ProtoField.uint32("zab.count", "Count")
-local f_state           = ProtoField.uint32("zab.state", "State")
-local f_child           = ProtoField.string("zab.child", "Child")
-
+local f_4lw = ProtoField.string("zab.4lw", "4LW message")
+local f_protoversion = ProtoField.uint64("zab.protocolversion", "Protocol Version")
+local f_zxid = ProtoField.uint64("zab.zxid", "ZxID", base.HEX)
+local f_zxid_epoch = ProtoField.uint32("zab.zxid.epoch", "Epoch")
+local f_zxid_count = ProtoField.uint32("zab.zxid.count", "Count")
+local f_czxid = ProtoField.uint64("zab.czxid", "Created ZxID", base.HEX)
+local f_czxid_epoch = ProtoField.uint32("zab.czxid.epoch", "Epoch")
+local f_czxid_count = ProtoField.uint32("zab.czxid.count", "Count")
+local f_mzxid = ProtoField.uint64("zab.mzxid", "Last Modified ZxID", base.HEX)
+local f_mzxid_epoch = ProtoField.uint32("zab.mzxid.epoch", "Epoch")
+local f_mzxid_count = ProtoField.uint32("zab.mzxid.count", "Count")
+local f_pzxid = ProtoField.uint64("zab.pzxid", "Last Modified Children ZxID", base.HEX)
+local f_pzxid_epoch = ProtoField.uint32("zab.pzxid.epoch", "Epoch")
+local f_pzxid_count = ProtoField.uint32("zab.pzxid.count", "Count")
+local f_timeout = ProtoField.uint32("zab.timeout", "Timeout")
+local f_session = ProtoField.uint64("zab.session", "Session ID", base.HEX)
+local f_len = ProtoField.uint32("zab.length", "Length", base.INT)
+local f_passwd = ProtoField.bytes("zab.passwd", "Password")
+local f_xid = ProtoField.int32("zab.xid", "Transaction ID", base.INT)
+local f_opCode = ProtoField.int32("zab.opcode", "OpCode", base.INT, opCodes)
+local f_data = ProtoField.bytes("zab.data", "Data")
+local f_path = ProtoField.string("zab.path", "Path")
+local f_watch = ProtoField.bool("zab.watch", "Watch")
+local f_ctime = ProtoField.uint64("zab.ctime", "Created", base.RELATIVE_TIME)
+local f_mtime = ProtoField.uint64("zab.mtime", "Last Modified", base.RELATIVE_TIME)
+local f_ephemeralowner = ProtoField.uint64("zab.ephemeralowner", "Ephemeral Owner", base.HEX)
+local f_numchildren = ProtoField.uint64("zab.numchildren", "Number of Children")
+local f_datalength = ProtoField.uint64("zab.datalength", "Data Length")
+local f_done = ProtoField.bool("zab.done", "Done")
+local f_err = ProtoField.int64("zab.err", "Error", base.INT, errorCodes)
+local f_perms = ProtoField.int64("zab.permissions", "Permissions")
+local f_authtype = ProtoField.int32("zab.authtype", "Authentication Type")
+local f_scheme = ProtoField.string("zab.scheme", "Scheme")
+local f_credential = ProtoField.string("zab.credential", "Credentials")
+local f_flags = ProtoField.uint32("zab.flags", "Flags", base.HEX)
+local f_ephemeral = ProtoField.bool("zab.ephemeral", "Ephemeral")
+local f_sequence = ProtoField.bool("zab.sequence", "Sequence")
+local f_container = ProtoField.bool("zab.container", "Container")
+local f_ttl = ProtoField.uint64("zab.ttl", "TTL")
+local f_joining = ProtoField.string("zab.joining", "Joining")
+local f_leaving = ProtoField.string("zab.leaving", "Leaving")
+local f_newmembers = ProtoField.string("zab.newmembers", "New Members")
+local f_config_id = ProtoField.uint64("zab.config_id", "Config ID", base.HEX)
+local f_version = ProtoField.uint64("zab.version", "Version")
+local f_cversion = ProtoField.uint64("zab.cversion", "Child Version")
+local f_aversion = ProtoField.uint64("zab.aversion", "ACL Version")
+local f_readonly = ProtoField.bool("zab.readonly", "Readonly")
+local f_eventtype = ProtoField.uint32("zab.eventtype", "Event Type", base.INT, watchEventTypes)
+local f_count = ProtoField.uint32("zab.count", "Count")
+local f_state = ProtoField.uint32("zab.state", "State")
+local f_child = ProtoField.string("zab.child", "Child")
 
 local CLIENTS = {}
 
@@ -178,7 +177,6 @@ local DissRes = {
     Client = Direction.Client2Server,
     Server = Direction.Server2Client,
 }
-
 
 ------------------------------------------------------------------------------
 local function defaultDissect(buf, pkt, tree, _offset, _stat)
@@ -202,52 +200,65 @@ local function parseStat(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local czxid = buf(offset, 8)
     offset = offset + 8
-    if offset + 8 > remain then return -1, nil end
-    local mzxid= buf(offset, 8)
+    if offset + 8 > remain then
+        return -1, nil
+    end
+    local mzxid = buf(offset, 8)
     offset = offset + 8
-    if offset + 16 > remain then return -1, nil end
+    if offset + 16 > remain then
+        return -1, nil
+    end
     local ctime = buf(offset, 8)
     local mtime = buf(offset + 8, 8)
     offset = offset + 16
-    if offset + 12 > remain then return -1, nil end
+    if offset + 12 > remain then
+        return -1, nil
+    end
     local version = buf(offset, 4)
     local cversion = buf(offset + 4, 4)
     local aversion = buf(offset + 8, 4)
     offset = offset + 12
-    if offset + 16 > remain then return -1, nil end
+    if offset + 16 > remain then
+        return -1, nil
+    end
     local ephemeralowner = buf(offset, 8)
     local datalength = buf(offset + 8, 4)
     local numchildren = buf(offset + 12, 4)
     offset = offset + 16
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local pzxid = buf(offset, 8)
     offset = offset + 8
 
-    return offset, {
-        czxid=czxid,
-        mzxid=mzxid,
-        ctime=ctime,
-        mtime=mtime,
-        version=version,
-        cversion=cversion,
-        aversion=aversion,
-        ephemeralowner=ephemeralowner,
-        datalength=datalength,
-        numchildren=numchildren,
-        pzxid=pzxid
-    }
+    return offset,
+        {
+            czxid = czxid,
+            mzxid = mzxid,
+            ctime = ctime,
+            mtime = mtime,
+            version = version,
+            cversion = cversion,
+            aversion = aversion,
+            ephemeralowner = ephemeralowner,
+            datalength = datalength,
+            numchildren = numchildren,
+            pzxid = pzxid,
+        }
 end
 
 local function reprStat(stat, tree)
-    local t_zxid = tree:add(f_czxid, stat.czxid)
-    t_zxid:add(f_czxid_epoch, stat.czxid(0, 4))
-    t_zxid:add(f_czxid_count, stat.czxid(4, 4))
-    local t_zxid = tree:add(f_mzxid, stat.mzxid)
-    t_zxid:add(f_mzxid_epoch, stat.mzxid(0, 4))
-    t_zxid:add(f_mzxid_count, stat.mzxid(4, 4))
+    local t_czxid = tree:add(f_czxid, stat.czxid)
+    t_czxid:add(f_czxid_epoch, stat.czxid(0, 4))
+    t_czxid:add(f_czxid_count, stat.czxid(4, 4))
+    local t_mzxid = tree:add(f_mzxid, stat.mzxid)
+    t_mzxid:add(f_mzxid_epoch, stat.mzxid(0, 4))
+    t_mzxid:add(f_mzxid_count, stat.mzxid(4, 4))
     tree:add(f_ctime, stat.ctime)
     tree:add(f_mtime, stat.mtime)
     tree:add(f_version, stat.version)
@@ -256,9 +267,9 @@ local function reprStat(stat, tree)
     tree:add(f_ephemeralowner, stat.ephemeralowner)
     tree:add(f_datalength, stat.datalength)
     tree:add(f_numchildren, stat.numchildren)
-    local t_zxid = tree:add(f_pzxid, stat.pzxid)
-    t_zxid:add(f_pzxid_epoch, stat.pzxid(0, 4))
-    t_zxid:add(f_pzxid_count, stat.pzxid(4, 4))
+    local t_pzxid = tree:add(f_pzxid, stat.pzxid)
+    t_pzxid:add(f_pzxid_epoch, stat.pzxid(0, 4))
+    t_pzxid:add(f_pzxid_count, stat.pzxid(4, 4))
 end
 
 -- Reads a string, returns length,str or 0,nil
@@ -266,11 +277,17 @@ local function parseString(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local str_length = buf(offset, 4):int()
     offset = offset + 4
-    if str_length == -1 then str_length = 0 end -- XXX: Is this correct??
-    if offset + str_length > remain then return -1, nil end
+    if str_length == -1 then
+        str_length = 0
+    end -- XXX: Is this correct??
+    if offset + str_length > remain then
+        return -1, nil
+    end
     local str = buf(offset, str_length)
     offset = offset + str_length
 
@@ -281,20 +298,26 @@ local function parseAcl(buf)
     -- 4 bytes perms, 4 bytes scheme length, scheme
     local offset = 0
     local remain = buf:len()
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local perms = buf(offset, 4)
     offset = offset + 4
     local scheme_offset, scheme = parseString(buf(offset))
-    if scheme_offset == -1 then return -1, nil end
+    if scheme_offset == -1 then
+        return -1, nil
+    end
     offset = offset + scheme_offset
     local cred_offset, credential = parseString(buf(offset))
-    if cred_offset == -1 then return -1, nil end
+    if cred_offset == -1 then
+        return -1, nil
+    end
     offset = offset + cred_offset
 
     return offset, {
-        perms=perms,
-        scheme=scheme,
-        credential=credential
+        perms = perms,
+        scheme = scheme,
+        credential = credential,
     }
 end
 
@@ -308,13 +331,17 @@ local function parseAclsArray(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local acls_count = buf(offset, 4):int()
     offset = offset + 4
     local acls = {}
     for i = 0, acls_count - 1 do
         local acl_offset, acl = parseAcl(buf(offset))
-        if acl_offset == -1 then return -1, nil end
+        if acl_offset == -1 then
+            return -1, nil
+        end
         offset = offset + acl_offset
         table.insert(acls, acl)
     end
@@ -333,16 +360,20 @@ local function parseResult(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local zxid = buf(offset, 8)
     offset = offset + 8
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local err = buf(offset, 4)
     offset = offset + 4
 
     return offset, {
-        zxid=zxid,
-        err=err
+        zxid = zxid,
+        err = err,
     }
 end
 
@@ -361,15 +392,19 @@ local function parseCheckRequest(buf)
     local remain = buf:len()
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local version = buf(offset, 4)
     offset = offset + 4
 
     return offset, {
-        path=path,
-        version=version,
+        path = path,
+        version = version,
     }
 end
 
@@ -380,7 +415,9 @@ end
 
 local function dissectCheckRequest(buf, pkt, tree, _state)
     local offset, check_req = parseCheckRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:append_text(" [CHECK]")
     reprCheckRequest(check_req, tree)
     return DissRes.Client
@@ -394,7 +431,8 @@ local function reprCheckReply(check_rep, tree)
     -- Nothing to do
 end
 
-local function dissectCheckReply(buf, pkt, tree, _state)
+-- reserved dispatch entry, currently disabled in dissectRepOpCode
+local function dissectCheckReply(buf, pkt, tree, _state) -- luacheck: ignore dissectCheckReply
     -- Nothing to do
 end
 
@@ -406,21 +444,27 @@ local function parseGetChildrenRequest(buf)
     local remain = buf:len()
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
-    if offset + 1 > remain then return -1, nil end
+    if offset + 1 > remain then
+        return -1, nil
+    end
     local watch = buf(offset, 1)
     offset = offset + 1
 
     return offset, {
-        path=path,
-        watch=watch,
+        path = path,
+        watch = watch,
     }
 end
 
 local function dissectGetChildrenRequest(buf, pkt, tree, _state)
     local offset, getchildren_req = parseGetChildrenRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:add(f_path, getchildren_req.path)
     tree:add(f_watch, getchildren_req.watch)
     return DissRes.Client
@@ -428,7 +472,9 @@ end
 
 local function dissectGetChildren2Request(buf, pkt, tree, _state)
     local offset, getchildren_req = parseGetChildrenRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:add(f_path, getchildren_req.path)
     tree:add(f_watch, getchildren_req.watch)
     return DissRes.Client
@@ -438,26 +484,32 @@ local function parseGetChildrenReply(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local count = buf(offset, 4)
     offset = offset + 4
     local children = {}
     for i = 0, count:int() - 1 do
         local child_offset, child = parseString(buf(offset))
-        if child_offset == -1 then return -1, nil end
+        if child_offset == -1 then
+            return -1, nil
+        end
         offset = offset + child_offset
         table.insert(children, child)
     end
 
     return offset, {
-        count=count,
-        children=children,
+        count = count,
+        children = children,
     }
 end
 
 local function dissectGetChildrenReply(buf, pkt, tree, _state)
     local offset, getchildren_rep = parseGetChildrenReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     tree:add(f_count, getchildren_rep.count)
     for i, child in ipairs(getchildren_rep.children) do
@@ -470,30 +522,38 @@ local function parseGetChildren2Reply(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local count = buf(offset, 4)
     offset = offset + 4
     local children = {}
     for i = 0, count:uint() - 1 do
         local child_offset, child = parseString(buf(offset))
-        if child_offset == -1 then return -1, nil end
+        if child_offset == -1 then
+            return -1, nil
+        end
         offset = offset + child_offset
         table.insert(children, child)
     end
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        count=count,
-        children=children,
-        stat=stat
+        count = count,
+        children = children,
+        stat = stat,
     }
 end
 
 local function dissectGetChildren2Reply(buf, pkt, tree, _state)
     local offset, getchildren2_rep = parseGetChildren2Reply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     tree:add(f_count, getchildren2_rep.count)
     for i, child in ipairs(getchildren2_rep.children) do
@@ -511,25 +571,33 @@ local function parseSetAclRequest(buf)
     local remain = buf:len()
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
     local acls_offset, acls = parseAclsArray(buf(offset))
-    if acls_offset == -1 then return -1, nil end
+    if acls_offset == -1 then
+        return -1, nil
+    end
     offset = offset + acls_offset
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local version = buf(offset, 4)
     offset = offset + 4
 
     return offset, {
-        path=path,
-        acls=acls,
-        version=version,
+        path = path,
+        acls = acls,
+        version = version,
     }
 end
 
 local function dissectSetAclRequest(buf, pkt, tree, _state)
     local offset, setacl_req = parseSetAclRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:add(f_path, setacl_req.path)
     reprAclsArray(setacl_req.acls, tree)
     tree:add(f_version, setacl_req.version)
@@ -540,17 +608,21 @@ local function parseSetAclReply(buf)
     local offset = 0
 
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        stat=stat
+        stat = stat,
     }
 end
 
 local function dissectSetAclReply(buf, pkt, tree, _state)
     local offset, setacl_rep = parseSetAclReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     reprStat(setacl_rep.stat, tree)
     return DissRes.Server
@@ -563,18 +635,21 @@ local function parseGetAclRequest(buf)
     local offset = 0
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
 
-
     return offset, {
-        path=path,
+        path = path,
     }
 end
 
 local function dissectGetAclRequest(buf, pkt, tree, _state)
     local offset, getacl_req = parseGetAclRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:add(f_path, getacl_req.path)
     return DissRes.Client
 end
@@ -583,21 +658,27 @@ local function parseGetAclReply(buf)
     local offset = 0
 
     local acls_offset, acls = parseAclsArray(buf(offset))
-    if acls_offset == -1 then return -1, nil end
+    if acls_offset == -1 then
+        return -1, nil
+    end
     offset = offset + acls_offset
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        acls=acls,
-        stat=stat,
+        acls = acls,
+        stat = stat,
     }
 end
 
 local function dissectGetAclReply(buf, pkt, tree, _state)
     local offset, getacl_rep = parseGetAclReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprAclsArray(getacl_rep.acls, tree)
     reprStat(getacl_rep.stat, tree)
     return DissRes.Server
@@ -611,19 +692,25 @@ local function parseSetDataRequest(buf)
     local remain = buf:len()
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
     local data_offset, data = parseString(buf(offset))
-    if data_offset == -1 then return -1, nil end
+    if data_offset == -1 then
+        return -1, nil
+    end
     offset = offset + data_offset
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local version = buf(offset, 4)
     offset = offset + 4
 
     return offset, {
-        path=path,
-        data=data,
-        version=version,
+        path = path,
+        data = data,
+        version = version,
     }
 end
 
@@ -635,7 +722,9 @@ end
 
 local function dissectSetDataRequest(buf, pkt, tree, _state)
     local offset, setdata_req = parseSetDataRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprSetDataRequest(setdata_req, tree)
     return DissRes.Client
 end
@@ -644,11 +733,13 @@ local function parseSetDataReply(buf)
     local offset = 0
 
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        stat=stat
+        stat = stat,
     }
 end
 
@@ -656,7 +747,9 @@ local reprSetDataReply = reprStat
 
 local function dissectSetDataReply(buf, pkt, tree, _state)
     local offset, setdata_rep = parseSetDataReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     reprSetDataReply(setdata_rep.stat, tree)
     return DissRes.Server
@@ -669,21 +762,27 @@ local function parseGetDataRequest(buf)
     local offset = 0
     local remain = buf:len()
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
-    if offset + 1 > remain then return -1, nil end
+    if offset + 1 > remain then
+        return -1, nil
+    end
     local watch = buf(offset, 1)
     offset = offset + 1
 
     return offset, {
-        path=path,
-        watch=watch,
+        path = path,
+        watch = watch,
     }
 end
 
 local function dissectGetDataRequest(buf, pkt, tree, _state)
     local offset, getdata_req = parseGetDataRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:add(f_path, getdata_req.path)
     tree:add(f_watch, getdata_req.watch)
     return DissRes.Client
@@ -692,21 +791,27 @@ end
 local function parseGetDataReply(buf)
     local offset = 0
     local data_offset, data = parseString(buf(offset))
-    if data_offset == -1 then return -1, nil end
+    if data_offset == -1 then
+        return -1, nil
+    end
     offset = offset + data_offset
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        data=data,
-        stat=stat
+        data = data,
+        stat = stat,
     }
 end
 
 local function dissectGetDataReply(buf, pkt, tree, _state)
     local offset, getdata_rep = parseGetDataReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:add(f_data, getdata_rep.data)
     reprStat(getdata_rep.stat, tree)
     return DissRes.Server
@@ -736,15 +841,19 @@ local function parseDeleteRequest(buf)
     local remain = buf:len()
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local version = buf(offset, 4)
     offset = offset + 4
 
     return offset, {
-        path=path,
-        version=version,
+        path = path,
+        version = version,
     }
 end
 
@@ -755,7 +864,9 @@ end
 
 local function dissectDeleteRequest(buf, pkt, tree, _state)
     local offset, delete_req = parseDeleteRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprDeleteRequest(delete_req, tree)
     return DissRes.Client
 end
@@ -770,9 +881,12 @@ local function reprDeleteReply(delete_rep, tree)
     return
 end
 
-local function dissectDeleteReply(buf, pkt, tree, _state)
-    local offset, delete_rep = parseDeleteReply(buf)
-    if offset == -1 then return false end
+-- reserved dispatch entry, currently disabled in dissectRepOpCode
+local function dissectDeleteReply(buf, pkt, tree, _state) -- luacheck: ignore dissectDeleteReply
+    local offset = parseDeleteReply(buf)
+    if offset == -1 then
+        return false
+    end
     return DissRes.Server
 end
 
@@ -783,21 +897,27 @@ local function parseExistsRequest(buf)
     local offset = 0
     local remain = buf:len()
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
-    if offset + 1 > remain then return -1, nil end
+    if offset + 1 > remain then
+        return -1, nil
+    end
     local watch = buf(offset, 1)
     offset = offset + 1
 
     return offset, {
-        path=path,
-        watch=watch,
+        path = path,
+        watch = watch,
     }
 end
 
 local function dissectExistsRequest(buf, pkt, tree, _state)
     local offset, exists_req = parseExistsRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:add(f_path, exists_req.path)
     tree:add(f_watch, exists_req.watch)
     return DissRes.Client
@@ -806,17 +926,21 @@ end
 local function parseExistsReply(buf)
     local offset = 0
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        stat=stat,
+        stat = stat,
     }
 end
 
 local function dissectExistsReply(buf, pkt, tree, _state)
     local offset, exists_rep = parseExistsReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprStat(exists_rep.stat, tree)
     return DissRes.Server
 end
@@ -829,24 +953,33 @@ local function parseReconfigRequest(buf)
     local remain = buf:len()
 
     local joining_offset, joining = parseString(buf(offset))
-    if joining_offset == -1 then return -1, nil end
+    if joining_offset == -1 then
+        return -1, nil
+    end
     offset = offset + joining_offset
     local leaving_offset, leaving = parseString(buf(offset))
-    if leaving_offset == -1 then return -1, nil end
+    if leaving_offset == -1 then
+        return -1, nil
+    end
     offset = offset + leaving_offset
     local new_members_offset, new_members = parseString(buf(offset))
-    if new_members_offset == -1 then return -1, nil end
+    if new_members_offset == -1 then
+        return -1, nil
+    end
     offset = offset + new_members_offset
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local config_id = buf(offset, 8)
     offset = offset + 8
 
-    return offset, {
-        joining=joining,
-        leaving=leaving,
-        new_members=new_members,
-        config_id=config_id,
-    }
+    return offset,
+        {
+            joining = joining,
+            leaving = leaving,
+            new_members = new_members,
+            config_id = config_id,
+        }
 end
 
 local function reprReconfigRequest(reconfig_req, tree)
@@ -858,7 +991,9 @@ end
 
 local function dissectReconfigRequest(buf, pkt, tree, _state)
     local offset, reconfig_req = parseReconfigRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprReconfigRequest(reconfig_req, tree)
     return DissRes.Client
 end
@@ -866,15 +1001,19 @@ end
 local function parseReconfigReply(buf)
     local offset = 0
     local data_offset, data = parseString(buf(offset))
-    if data_offset == -1 then return -1, nil end
+    if data_offset == -1 then
+        return -1, nil
+    end
     offset = offset + data_offset
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        data=data,
-        stat=stat,
+        data = data,
+        stat = stat,
     }
 end
 
@@ -884,7 +1023,9 @@ end
 
 local function dissectReconfigReply(buf, pkt, tree, _state)
     local offset, reconfig_rep = parseReconfigReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprReconfigReply(reconfig_rep, tree)
     return DissRes.Server
 end
@@ -896,11 +1037,13 @@ local function parseSyncRequest(buf)
     local offset = 0
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
 
     return offset, {
-        path=path
+        path = path,
     }
 end
 
@@ -910,7 +1053,9 @@ end
 
 local function dissectSyncRequest(buf, pkt, tree, _state)
     local offset, sync_req = parseSyncRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:append_text(" [SYNC]")
     reprSyncRequest(sync_req, tree)
     return DissRes.Client
@@ -920,11 +1065,13 @@ local function parseSyncReply(buf)
     local offset = 0
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
 
     return offset, {
-        path=path
+        path = path,
     }
 end
 
@@ -934,7 +1081,9 @@ end
 
 local function dissectSyncReply(buf, pkt, tree, _state)
     local offset, sync_rep = parseSyncReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     tree:append_text(" [SYNC REP]")
     reprSyncReply(sync_rep, tree)
     return DissRes.Server
@@ -947,23 +1096,31 @@ local function parseCreateRequest(buf)
     local offset = 0
     local remain = buf:len()
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
     local data_offset, data = parseString(buf(offset))
-    if data_offset == -1 then return -1, nil end
+    if data_offset == -1 then
+        return -1, nil
+    end
     offset = offset + data_offset
     local acls_offset, acls = parseAclsArray(buf(offset))
-    if acls_offset == -1 then return -1, nil end
+    if acls_offset == -1 then
+        return -1, nil
+    end
     offset = offset + acls_offset
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local flags = buf(offset, 4)
     offset = offset + 4
 
     return offset, {
-        path=path,
-        data=data,
-        acls=acls,
-        flags=flags,
+        path = path,
+        data = data,
+        acls = acls,
+        flags = flags,
     }
 end
 
@@ -982,7 +1139,9 @@ end
 
 local function dissectCreateRequest(buf, pkt, tree, _state)
     local offset, create_req = parseCreateRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreateRequest(create_req, tree)
     return DissRes.Client
 end
@@ -990,11 +1149,13 @@ end
 local function parseCreateReply(buf)
     local offset = 0
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
 
     return offset, {
-        path=path
+        path = path,
     }
 end
 
@@ -1004,11 +1165,12 @@ end
 
 local function dissectCreateReply(buf, pkt, tree, _state)
     local offset, create_rep = parseCreateReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreateReply(create_rep, tree)
     return DissRes.Server
 end
-
 
 local parseCreate2Request = parseCreateRequest
 
@@ -1016,7 +1178,9 @@ local reprCreate2Request = reprCreateRequest
 
 local function dissectCreate2Request(buf, pkt, tree, _state)
     local offset, create_req = parseCreate2Request(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreate2Request(create_req, tree)
     return DissRes.Client
 end
@@ -1025,16 +1189,20 @@ local function parseCreate2Reply(buf)
     local offset = 0
 
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
 
     local stat_offset, stat = parseStat(buf(offset))
-    if stat_offset == -1 then return -1, nil end
+    if stat_offset == -1 then
+        return -1, nil
+    end
     offset = offset + stat_offset
 
     return offset, {
-        path=path,
-        stat=stat,
+        path = path,
+        stat = stat,
     }
 end
 
@@ -1045,11 +1213,12 @@ end
 
 local function dissectCreate2Reply(buf, pkt, tree, _state)
     local offset, create_rep = parseCreate2Reply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreate2Reply(create_rep, tree)
     return DissRes.Server
 end
-
 
 local parseCreateContainerRequest = parseCreateRequest
 
@@ -1057,7 +1226,9 @@ local reprCreateContainerRequest = reprCreateRequest
 
 local function dissectCreateContainerRequest(buf, pkt, tree, _state)
     local offset, create_container_req = parseCreateContainerRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreateContainerRequest(create_container_req, tree)
     return DissRes.Client
 end
@@ -1068,38 +1239,50 @@ local reprCreateContainerReply = reprCreate2Reply
 
 local function dissectCreateContainerReply(buf, pkt, tree, _state)
     local offset, create_container_rep = parseCreateContainerReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreateContainerReply(create_container_rep, tree)
     return DissRes.Server
 end
-
 
 local function parseCreateTTLRequest(buf)
     local offset = 0
     local remain = buf:len()
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
     local data_offset, data = parseString(buf(offset))
-    if data_offset == -1 then return -1, nil end
+    if data_offset == -1 then
+        return -1, nil
+    end
     offset = offset + data_offset
     local acls_offset, acls = parseAclsArray(buf(offset))
-    if acls_offset == -1 then return -1, nil end
+    if acls_offset == -1 then
+        return -1, nil
+    end
     offset = offset + acls_offset
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local flags = buf(offset, 4)
     offset = offset + 4
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local ttl = buf(offset, 8)
     offset = offset + 8
 
-    return offset, {
-        path=path,
-        data=data,
-        acls=acls,
-        flags=flags,
-        ttl=ttl,
-    }
+    return offset,
+        {
+            path = path,
+            data = data,
+            acls = acls,
+            flags = flags,
+            ttl = ttl,
+        }
 end
 
 local function reprCreateTTLRequest(create_ttl_req, tree)
@@ -1118,7 +1301,9 @@ end
 
 local function dissectCreateTTLRequest(buf, pkt, tree, _state)
     local offset, create_ttl_req = parseCreateTTLRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreateTTLRequest(create_ttl_req, tree)
     return DissRes.Client
 end
@@ -1129,11 +1314,12 @@ local reprCreateTTLReply = reprCreate2Reply
 
 local function dissectCreateTTLReply(buf, pkt, tree, _state)
     local offset, create_ttl_rep = parseCreateTTLReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     reprCreateTTLReply(create_ttl_rep, tree)
     return DissRes.Server
 end
-
 
 ------------------------------------------------------------------------------
 -- MULTI packets
@@ -1212,42 +1398,52 @@ local function parseMultiRequest(buf)
     local ops = {}
     repeat
         local start_offset = offset
-        if offset + 9 > remain then return -1, nil end
+        if offset + 9 > remain then
+            return -1, nil
+        end
         local opcode = buf(offset, 4)
         local done = buf(offset + 4, 1)
         local err = buf(offset + 5, 4)
         -- print("XXX Multi opCode", offset, opcode, done, err)
         offset = offset + 9
-        if done:int() == 1 then break end
+        if done:int() == 1 then
+            break
+        end
         -- PARSE the opCode here
         local req_parse_fun = parseReqOpCode[opcode:int()]
         -- print("XXX Multi fun", req_parse_fun)
-        if req_parse_fun == nil then return -1, nil end
+        if req_parse_fun == nil then
+            return -1, nil
+        end
         local req_offset, req_data = req_parse_fun(buf(offset))
-        if req_offset == -1 then return -1, nil end
+        if req_offset == -1 then
+            return -1, nil
+        end
         local req_raw_data = buf(offset, req_offset)
         -- print("XXX Multi req_data", req_offset, req_data, req_raw_data)
         offset = offset + req_offset
         local op_data = buf(start_offset, 9 + req_offset)
 
         table.insert(ops, {
-            opcode=opcode,
-            done=done,
-            err=err,
-            req_data=req_data,
-            req_raw_data=req_raw_data,
-            op_data=op_data
+            opcode = opcode,
+            done = done,
+            err = err,
+            req_data = req_data,
+            req_raw_data = req_raw_data,
+            op_data = op_data,
         })
     until done == 1
 
     return offset, {
-        ops=ops,
+        ops = ops,
     }
 end
 
 local function dissectMultiRequest(buf, pkt, tree, _state)
     local offset, multi_req = parseMultiRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     for i, op in ipairs(multi_req.ops) do
         local t_multi = tree:add(f_op)
@@ -1273,19 +1469,27 @@ local function parseMultiReply(buf)
     local ops = {}
     repeat
         local start_offset = offset
-        if offset + 9 > remain then return -1, nil end
+        if offset + 9 > remain then
+            return -1, nil
+        end
         local opcode = buf(offset, 4)
         local done = buf(offset + 4, 1)
         local err = buf(offset + 5, 4)
         -- print("XXX MultiRep opCode", offset, opcode, done, err)
         offset = offset + 9
-        if done:int() == 1 then break end
+        if done:int() == 1 then
+            break
+        end
         -- PARSE the opCode here
         local rep_parse_fun = parseRepOpCode[opcode:int()]
         -- print("XXX Multi fun", rep_parse_fun)
-        if rep_parse_fun == nil then return -1, nil end
+        if rep_parse_fun == nil then
+            return -1, nil
+        end
         local rep_offset, rep_data = rep_parse_fun(buf(offset))
-        if rep_offset == -1 then return -1, nil end
+        if rep_offset == -1 then
+            return -1, nil
+        end
         local rep_raw_data = buf(offset, rep_offset)
         -- print("XXX Multi rep_data", rep_offset, rep_data, rep_raw_data)
         offset = offset + rep_offset
@@ -1293,23 +1497,25 @@ local function parseMultiReply(buf)
         local op_data = buf(start_offset, 9 + rep_offset)
 
         table.insert(ops, {
-            opcode=opcode,
-            done=done,
-            err=err,
-            rep_data=rep_data,
-            rep_raw_data=rep_raw_data,
-            op_data=op_data,
+            opcode = opcode,
+            done = done,
+            err = err,
+            rep_data = rep_data,
+            rep_raw_data = rep_raw_data,
+            op_data = op_data,
         })
     until done == 1
 
     return offset, {
-        ops=ops,
+        ops = ops,
     }
 end
 
 local function dissectMultiReply(buf, pkt, tree, _state)
     local offset, multi_rep = parseMultiReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     for i, op in ipairs(multi_rep.ops) do
         local t_multi = tree:add(f_op, op.op_data)
@@ -1390,11 +1596,9 @@ end
 
 local function dissect4lw(buf, pkt, tree)
     local fourlw = buf(0, 4):string()
-    local res = nil
+    local res
     if FOUR_LETTER_WORDS[fourlw] ~= nil then
-        pkt.cols.info:set(
-            string.format("4LW %s request", fourlw)
-        )
+        pkt.cols.info:set(string.format("4LW %s request", fourlw))
         res = Direction.Client2Server
     else
         pkt.cols.info:set("4LW reply")
@@ -1413,33 +1617,39 @@ local function parseWatchEvent(buf)
     local remain = buf:len()
     -- Result fields
     local result_offset, result = parseResult(buf(offset))
-    if result_offset == -1 then return -1, nil end
+    if result_offset == -1 then
+        return -1, nil
+    end
     offset = offset + result_offset
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local eventtype = buf(offset, 4)
     offset = offset + 4
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local state = buf(offset, 4)
     offset = offset + 4
     local path_offset, path = parseString(buf(offset))
-    if path_offset == -1 then return -1, nil end
+    if path_offset == -1 then
+        return -1, nil
+    end
     offset = offset + path_offset
 
-    return offset, {
-        result=result,
-        eventtype=eventtype,
-        state=state,
-        path=path
-    }
+    return offset,
+        {
+            result = result,
+            eventtype = eventtype,
+            state = state,
+            path = path,
+        }
 end
 
 local function dissectWatchEvent(buf, pkt, tree)
-    local offset, watchevent = parseWatchEvent(buf)
+    local _, watchevent = parseWatchEvent(buf)
     pkt.cols.info:set("WATCH EVENT")
-    tree:append_text(
-        string.format(" [WATCH EVENT: %s]",
-                      watchEventTypes[watchevent.eventtype:int()])
-    )
+    tree:append_text(string.format(" [WATCH EVENT: %s]", watchEventTypes[watchevent.eventtype:int()]))
     local t_zxid = tree:add(f_zxid, watchevent.result.zxid)
     t_zxid:add(f_zxid_epoch, watchevent.result.zxid(0, 4))
     t_zxid:add(f_zxid_count, watchevent.result.zxid(4, 4))
@@ -1459,59 +1669,72 @@ local function parseSetWatchesRequest(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local dataw_num = buf(offset, 4)
     offset = offset + 4
     local dataw = {}
     for i = 0, dataw_num:uint() - 1 do
         local path_offset, path = parseString(buf(offset))
-        if path_offset == -1 then return -1, nil end
+        if path_offset == -1 then
+            return -1, nil
+        end
         offset = offset + path_offset
         table:insert(dataw, path)
     end
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local existsw_num = buf(offset, 4)
     offset = offset + 4
     local existsw = {}
     for i = 0, existsw_num:uint() - 1 do
         local path_offset, path = parseString(buf(offset))
-        if path_offset == -1 then return -1, nil end
+        if path_offset == -1 then
+            return -1, nil
+        end
         offset = offset + path_offset
         table:insert(existsw, path)
     end
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local childw_num = buf(offset, 4)
     offset = offset + 4
     local childw = {}
     for i = 0, childw_num:uint() - 1 do
         local path_offset, path = parseString(buf(offset))
-        if path_offset == -1 then return -1, nil end
+        if path_offset == -1 then
+            return -1, nil
+        end
         offset = offset + path_offset
         table:insert(childw, path)
     end
 
-    return offset, {
-        dataw_num=dataw_num,
-        dataw=dataw,
-        existsw_num=existsw_num,
-        existsw=existsw,
-        childw_num=childw_num,
-        childw=childw,
-    }
+    return offset,
+        {
+            dataw_num = dataw_num,
+            dataw = dataw,
+            existsw_num = existsw_num,
+            existsw = existsw,
+            childw_num = childw_num,
+            childw = childw,
+        }
 end
 
 local function reprSetWatchesRequest(setwatches_req, tree)
-    t_dataw = tree:add(f_op) -- "Data Watches"
+    local t_dataw = tree:add(f_op) -- "Data Watches"
     t_dataw:add(f_count, setwatches_req.dataw_num)
     for i, path in ipairs(setwatches_req.dataw) do
         t_dataw:add(f_path, path)
     end
-    t_existsw = tree:add(f_op) -- "Exists Watches"
+    local t_existsw = tree:add(f_op) -- "Exists Watches"
     t_existsw:add(f_count, setwatches_req.existsw_num)
     for i, path in ipairs(setwatches_req.existsw) do
         t_existsw:add(f_path, path)
     end
-    t_childw = tree:add(f_op) -- "Children Watches"
+    local t_childw = tree:add(f_op) -- "Children Watches"
     t_childw:add(f_count, setwatches_req.childw_num)
     for i, path in ipairs(setwatches_req.childw) do
         t_childw:add(f_path, path)
@@ -1520,7 +1743,9 @@ end
 
 local function dissectSetWatchesRequest(buf, pkt, tree, _state)
     local offset, setwatches_req = parseSetWatchesRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     pkt.cols.info:set("SETWATCHES REQUEST")
     tree:append_text(" [SETWATCHES REQUEST]")
     reprSetWatchesRequest(setwatches_req, tree)
@@ -1534,20 +1759,26 @@ local function parseSetAuthRequest(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local authtype = buf(offset, 4)
     offset = offset + 4
     local scheme_offset, scheme = parseString(buf(offset))
-    if scheme_offset == -1 then return -1, nil end
+    if scheme_offset == -1 then
+        return -1, nil
+    end
     offset = offset + scheme_offset
     local credential_offset, credential = parseString(buf(offset))
-    if credential_offset == -1 then return -1, nil end
+    if credential_offset == -1 then
+        return -1, nil
+    end
     offset = offset + credential_offset
 
     return offset, {
-        authtype=authtype,
-        scheme=scheme,
-        credential=credential
+        authtype = authtype,
+        scheme = scheme,
+        credential = credential,
     }
 end
 
@@ -1569,26 +1800,34 @@ local function parseAuthRequest(buf)
     local offset = 0
     local remain = buf:len()
 
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local opcode = buf(offset, 4)
     offset = offset + 4
 
     local req_parse_fun = parseAuthReqOpCode[opcode:int()]
-    if req_parse_fun == nil then return -1, nil end
+    if req_parse_fun == nil then
+        return -1, nil
+    end
 
     local authdata_offset, authdata = req_parse_fun(buf(offset))
-    if authdata_offset == -1 then return -1, nil end
+    if authdata_offset == -1 then
+        return -1, nil
+    end
     offset = offset + authdata_offset
 
     return offset, {
-        opcode=opcode,
-        authdata=authdata
+        opcode = opcode,
+        authdata = authdata,
     }
 end
 
 local function dissectAuthRequest(buf, pkt, tree, _state)
     local offset, auth_req = parseAuthRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     pkt.cols.info:set("AUTH REQUEST")
     tree:append_text(" [AUTH REQ]")
@@ -1606,17 +1845,21 @@ local function parseAuthReply(buf)
     local offset = 0
 
     local result_offset, result = parseResult(buf(offset))
-    if result_offset == -1 then return false end
+    if result_offset == -1 then
+        return false
+    end
     offset = offset + result_offset
 
     return offset, {
-        result=result,
+        result = result,
     }
 end
 
 local function dissectAuthReply(buf, pkt, tree, _state)
     local offset, auth_rep = parseAuthReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
 
     pkt.cols.info:set("AUTH REPLY")
     tree:append_text(" [AUTH REP]")
@@ -1631,38 +1874,53 @@ end
 local function parseConnectRequest(buf)
     local offset = 0
     local remain = buf:len()
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local protoversion = buf(offset, 4)
     offset = offset + 4
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local zxid = buf(offset, 8)
     offset = offset + 8
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local timeout = buf(offset, 4)
     offset = offset + 4
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local session = buf(offset, 8)
     offset = offset + 8
     local passwd_offset, passwd = parseString(buf(offset))
-    if passwd_offset == -1 then return -1, nil end
+    if passwd_offset == -1 then
+        return -1, nil
+    end
     offset = offset + passwd_offset
-    if offset + 1 > remain then return -1, nil end
+    if offset + 1 > remain then
+        return -1, nil
+    end
     local readonly = buf(offset, 1)
     offset = offset + 1
 
-    return offset, {
-        protoversion=protoversion,
-        zxid=zxid,
-        timeout=timeout,
-        session=session,
-        passwd=passwd,
-        readonly=readonly,
-    }
+    return offset,
+        {
+            protoversion = protoversion,
+            zxid = zxid,
+            timeout = timeout,
+            session = session,
+            passwd = passwd,
+            readonly = readonly,
+        }
 end
 
 local function dissectConnectRequest(buf, pkt, tree)
     local offset, conn_req = parseConnectRequest(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     pkt.cols.info:set("CONNECT REQUEST")
     tree:append_text(" [CONNECT REQ]")
     tree:add(f_protoversion, conn_req.protoversion)
@@ -1677,34 +1935,47 @@ end
 local function parseConnectReply(buf)
     local offset = 0
     local remain = buf:len()
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local protoversion = buf(offset, 4)
     offset = offset + 4
-    if offset + 4 > remain then return -1, nil end
+    if offset + 4 > remain then
+        return -1, nil
+    end
     local timeout = buf(offset, 4)
     offset = offset + 4
-    if offset + 8 > remain then return -1, nil end
+    if offset + 8 > remain then
+        return -1, nil
+    end
     local session = buf(offset, 8)
     offset = offset + 8
     local passwd_offset, passwd = parseString(buf(offset))
-    if passwd_offset == -1 then return -1, nil end
+    if passwd_offset == -1 then
+        return -1, nil
+    end
     offset = offset + passwd_offset
-    if offset + 1 > remain then return -1, nil end
+    if offset + 1 > remain then
+        return -1, nil
+    end
     local readonly = buf(offset, 1)
     offset = offset + 1
 
-    return offset, {
-        protoversion=protoversion,
-        timeout=timeout,
-        session=session,
-        passwd=passwd,
-        readonly=readonly,
-    }
+    return offset,
+        {
+            protoversion = protoversion,
+            timeout = timeout,
+            session = session,
+            passwd = passwd,
+            readonly = readonly,
+        }
 end
 
 local function dissectConnectReply(buf, pkt, tree)
     local offset, conn_rep = parseConnectReply(buf)
-    if offset == -1 then return false end
+    if offset == -1 then
+        return false
+    end
     pkt.cols.info:set("CONNECT REPLY")
     tree:append_text(" [CONNECT REP]")
     tree:add(f_protoversion, conn_rep.protoversion)
@@ -1720,14 +1991,18 @@ end
 
 local function dissectPingRequest(buf, pkt, tree)
     tree:append_text(" [PING]")
-    if buf:len() ~= 4 then return false end
+    if buf:len() ~= 4 then
+        return false
+    end
     tree:add(f_opCode, buf(0, 4))
     return DissRes.Client
 end
 
 local function dissectPingReply(buf, pkt, tree)
     tree:append_text(" [PING REP]")
-    if buf:len() ~= 12 then return false end
+    if buf:len() ~= 12 then
+        return false
+    end
     -- XXX: Parse ping reply payload
     tree:add(f_data, buf(0, 12))
     return DissRes.Server
@@ -1771,14 +2046,18 @@ local function dissect(buf, pkt, tree, state)
     local remain = buf:len()
 
     -- We need at list 8 bytes for len+xid
-    if offset + 8 > remain then return false end
+    if offset + 8 > remain then
+        return false
+    end
 
     tree:add(f_len, buf(offset, 4))
     offset = offset + 4
     local xidBuf = buf(offset, 4)
     local xid = xidBuf:int()
     if xid <= 0 then
-        if FIXED_XIDS[xid] == nil then return false end
+        if FIXED_XIDS[xid] == nil then
+            return false
+        end
         -- NOTE: CONNECT packet starts *on* the xid, so for those, do not
         -- extract field/update offset
         if xid ~= 0 then
@@ -1810,14 +2089,18 @@ local function dissect(buf, pkt, tree, state)
                 tree:append_text(string.format(" [%s REP]", opCodes[opCode]))
             end
             local result_offset, result = parseResult(buf(offset))
-            if result_offset == -1 then return false end
+            if result_offset == -1 then
+                return false
+            end
             offset = offset + result_offset
             reprResult(result, tree)
         else
             -- We don't know the direction.
             return false
         end
-        if offset == remain then return state.dir end
+        if offset == remain then
+            return state.dir
+        end
         -- check if we know about this XID
         if opCode == nil then
             -- We don't know about this request, dump the payload
@@ -1829,44 +2112,86 @@ local function dissect(buf, pkt, tree, state)
     end
 end
 
-local function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
-      end
-      return s .. '} '
-   else
-      return tostring(o)
-   end
+-- debugging helper, only used from commented-out PRINT statements
+local function dump(o) -- luacheck: ignore dump
+    if type(o) == "table" then
+        local s = "{ "
+        for k, v in pairs(o) do
+            if type(k) ~= "number" then
+                k = '"' .. k .. '"'
+            end
+            s = s .. "[" .. k .. "] = " .. dump(v) .. ","
+        end
+        return s .. "} "
+    else
+        return tostring(o)
+    end
 end
 
 ------------------------------------------------------------------------------
 ZabProto = Proto("ZAB", "ZAB 1.0")
 
 local default_settings = {
-    port = DEFAULT_ZAB_PORT -- Since a client may talk to many servers, on different ports, this should be the client port
+    port = DEFAULT_ZAB_PORT, -- Since a client may talk to many servers, on different ports, this should be the client port
+    ports = { DEFAULT_ZAB_PORT },
 }
 
-ZabProto.prefs.port  = Pref.uint(
-    "Port number",
-    default_settings.port,
-    "The TCP port number for ZAB"
-)
-
+ZabProto.prefs.port = Pref.uint("Port number", default_settings.port, "The TCP port number for ZAB")
 
 ZabProto.fields = {
-    f_pkt, f_op, -- Structural fields
-    f_4lw, f_len, f_xid, f_data, f_opCode, f_path, f_watch, f_protoversion,
-    f_zxid, f_zxid_epoch, f_zxid_count, f_timeout, f_session, f_authtype,
-    f_perms, f_scheme, f_credential, f_datalength, f_flags, f_ephemeral,
-    f_sequence, f_container, f_ttl, f_joining, f_leaving, f_newmembers,
-    f_config_id, f_done, f_err, f_version, f_eventtype, f_state, f_passwd,
-    f_readonly, f_count, f_child, f_czxid, f_czxid_epoch, f_czxid_count,
-    f_mzxid, f_mzxid_epoch, f_mzxid_count, f_ctime, f_mtime, f_cversion,
-    f_aversion, f_ephemeralowner, f_numchildren, f_pzxid, f_pzxid_epoch,
-    f_pzxid_count
+    f_pkt,
+    f_op, -- Structural fields
+    f_4lw,
+    f_len,
+    f_xid,
+    f_data,
+    f_opCode,
+    f_path,
+    f_watch,
+    f_protoversion,
+    f_zxid,
+    f_zxid_epoch,
+    f_zxid_count,
+    f_timeout,
+    f_session,
+    f_authtype,
+    f_perms,
+    f_scheme,
+    f_credential,
+    f_datalength,
+    f_flags,
+    f_ephemeral,
+    f_sequence,
+    f_container,
+    f_ttl,
+    f_joining,
+    f_leaving,
+    f_newmembers,
+    f_config_id,
+    f_done,
+    f_err,
+    f_version,
+    f_eventtype,
+    f_state,
+    f_passwd,
+    f_readonly,
+    f_count,
+    f_child,
+    f_czxid,
+    f_czxid_epoch,
+    f_czxid_count,
+    f_mzxid,
+    f_mzxid_epoch,
+    f_mzxid_count,
+    f_ctime,
+    f_mtime,
+    f_cversion,
+    f_aversion,
+    f_ephemeralowner,
+    f_numchildren,
+    f_pzxid,
+    f_pzxid_epoch,
+    f_pzxid_count,
 }
 
 function ZabProto.dissector(buf, pkt, root)
@@ -1883,7 +2208,7 @@ function ZabProto.dissector(buf, pkt, root)
     local sender = string.format("%s:%s", pkt.src, pkt.src_port)
     local recipient = string.format("%s:%s", pkt.dst, pkt.dst_port)
 
-    local state = {sender=sender, recipient=recipient, dir=nil, xids=nil}
+    local state = { sender = sender, recipient = recipient, dir = nil, xids = nil }
     if CLIENTS[sender] ~= nil then
         state.xids = CLIENTS[sender]
         state.dir = Direction.Client2Server
@@ -1894,7 +2219,7 @@ function ZabProto.dissector(buf, pkt, root)
 
     -- Handle fragmentation or combining of packets
     -- https://wiki.wireshark.org/Lua/Dissectors#TCP_reassembly
-    local res = nil
+    local res
     local start_offset = 0 -- current start of a packet
     local remain = buf:len()
 
@@ -1919,15 +2244,13 @@ function ZabProto.dissector(buf, pkt, root)
             -- This is 'AAAA' as int (or a length of about 1GB)
             packet_length = remain -- 4lw eats the whole packet
             local pktBuf = buf(start_offset)
-            local t_pkt = tree:add(f_pkt,  pktBuf)
+            local t_pkt = tree:add(f_pkt, pktBuf)
             res = dissect4lw(pktBuf, pkt, t_pkt)
-
         elseif packet_length > (remain - offset) then
             pkt.desegment_offset = start_offset -- restart @ packet start
-            pkt.desegment_len = packet_length - (remain - offset) 
+            pkt.desegment_len = packet_length - (remain - offset)
             -- print("Fragmented", pkt.desegment_offset, pkt.desegment_len)
             return
-
         else -- packet_length <= buf:len()
             -- We can parse at least one packet, from start_offset, [length, packet]
             local pktBuf = buf(start_offset, 4 + packet_length)
@@ -1950,13 +2273,12 @@ function ZabProto.dissector(buf, pkt, root)
                 -- print("NEW CLIENT", recipient)
                 CLIENTS[recipient] = {}
             end
-        else -- res == true
-            -- Nothing to do?
         end
+        -- res is anything else (e.g. true) -- nothing further to do
         -- Move forward by a packet_len field + the packet length
         start_offset = start_offset + 4 + packet_length
 
-        -- Did we reach the end?
+    -- Did we reach the end?
     until start_offset == remain
 
     -- print("State:", dump(CLIENTS))
@@ -1966,24 +2288,27 @@ end
 -- a function for handling prefs being changed
 function ZabProto.prefs_changed()
     if default_settings.port ~= ZabProto.prefs.port then
-        -- remove old one, if not 0
-        if default_settings.port ~= 0 then
-            DissectorTable.get("tcp.port"):remove(default_settings.port, ZabProto)
+        local tcp_dissector_table = DissectorTable.get("tcp.port")
+        -- remove all previously registered ports
+        for _, port in ipairs(default_settings.ports) do
+            tcp_dissector_table:remove(port, ZabProto)
         end
         -- set our new default
         default_settings.port = ZabProto.prefs.port
-        -- add new one, if not 0
+        default_settings.ports = { default_settings.port }
+        -- add the new one, if not 0
         if default_settings.port ~= 0 then
-            DissectorTable.get("tcp.port"):add(default_settings.port, ZabProto)
+            tcp_dissector_table:add(default_settings.port, ZabProto)
         end
     end
-
 end
 
 function ZabProto.init()
     local tcp_dissector_table = DissectorTable.get("tcp.port")
     tcp_dissector_table:add_for_decode_as(ZabProto)
-    tcp_dissector_table:add(default_settings.port, ZabProto)
+    for _, port in ipairs(default_settings.ports) do
+        tcp_dissector_table:add(port, ZabProto)
+    end
 end
 
 ----------------------------------------
@@ -1992,20 +2317,41 @@ end
 -- line using the '-o' switch (the preferences don't exist until this script is
 -- loaded, so the command line thinks they're invalid preferences being set)
 -- so we pass them in as command arguments instead, and handle it here:
-local args={...} -- get passed-in args
-if args and #args > 0 then
-    for _, arg in ipairs(args) do
-        local name, value = arg:match("(.+)=(.+)")
-        if name and value then
-            if tonumber(value) then
-                value = tonumber(value)
-            else
-                error("invalid commandline argument value")
-            end
-        else
+local function apply_cli_args(args)
+    for i = 1, #args do
+        local name, value = args[i]:match("(.+)=(.+)")
+        if not name or not value then
             error("invalid commandline argument syntax")
         end
 
-        default_settings[name] = value
+        if name == "port" then
+            local port = tonumber(value)
+            if not port then
+                error("invalid commandline argument value")
+            end
+            default_settings.port = port
+            default_settings.ports = { port }
+        elseif name == "ports" then
+            local new_ports = {}
+            for port_str in string.gmatch(value, "([^,]+)") do
+                local port = tonumber(port_str)
+                if not port then
+                    error("invalid commandline argument value")
+                end
+                table.insert(new_ports, port)
+            end
+            if #new_ports == 0 then
+                error("invalid commandline argument value")
+            end
+            default_settings.ports = new_ports
+            default_settings.port = new_ports[1]
+        else
+            error("invalid commandline argument syntax")
+        end
     end
+end
+
+local args = { ... } -- get passed-in args
+if args and #args > 0 then
+    apply_cli_args(args)
 end


### PR DESCRIPTION
Adds GitHub Actions CI so every PR runs the project's existing Lua lint and format checks inside a Nix dev shell (`flake.nix`).

- `.github/workflows/lua-checks.yml`: bare `pull_request` trigger, read-only permissions, concurrency cancellation; two jobs (`lint`, `format`) run `nix develop --command ./scripts/…` verbatim
- `flake.nix` + `flake.lock`: single source of truth for `luacheck` + `stylua` tooling (CI == local)
- README documents the `nix develop` workflow and the CI reference